### PR TITLE
Fixed session management

### DIFF
--- a/Multirowtabs/Firefox-108/01-MultiRowTabLiteforFx.uc.js
+++ b/Multirowtabs/Firefox-108/01-MultiRowTabLiteforFx.uc.js
@@ -35,9 +35,6 @@ function MultiRowTabLiteforFx() {
     .tabbrowser-tab > .tab-stack { width: 100% !important; }
     #TabsToolbar .toolbarbutton-1 { margin: 0 !important; padding: 0 !important; }
 
-    /* Ausblenden - Verstecken */
-    .tabbrowser-tab:not([fadein]),#alltabs-button { display: none !important; }
-
     /* --- Ziehbereich der Tab-Leiste --- */
 
     /* Anpassung */

--- a/Multirowtabs/Firefox-108/02-MultiRowTabLiteforFx.uc.js
+++ b/Multirowtabs/Firefox-108/02-MultiRowTabLiteforFx.uc.js
@@ -38,9 +38,6 @@ function MultiRowTabLiteforFx() {
     .tabbrowser-tab > .tab-stack { width: 100% !important; }
     #TabsToolbar .toolbarbutton-1 { margin: 0 !important; padding: 0 !important;}
 
-    /* Ausblenden */
-    .tabbrowser-tab:not([fadein]),#alltabs-button { display: none !important; }
-
     /* --- Ziehbereich der Tab-Leiste --- */
     /* Anpassung */
     hbox.titlebar-spacer[type="pre-tabs"] { width: 0px !important; } /* Linker Ziehbereich: Standard 40px  */

--- a/Multirowtabs/Firefox-108/03-MultiRowTabLiteforFx.uc.js
+++ b/Multirowtabs/Firefox-108/03-MultiRowTabLiteforFx.uc.js
@@ -40,9 +40,6 @@ function MultiRowTabLiteforFx() {
     .tabbrowser-tab > .tab-stack { width: 100% !important; }
     #TabsToolbar .toolbarbutton-1 { margin: 0 !important; padding: 0 !important; }
 
-    /* Ausblenden - Verstecken  */
-    .tabbrowser-tab:not([fadein]),#alltabs-button { display: none !important; }
-
    /* --- Ziehbereich der Tab-Leiste --- */
     
     /* Anpassung */

--- a/Multirowtabs/Firefox-108/04-MultiRowTabLiteforFx.uc.js
+++ b/Multirowtabs/Firefox-108/04-MultiRowTabLiteforFx.uc.js
@@ -43,9 +43,6 @@ function MultiRowTabLiteforFx() {
     .tabbrowser-tab > .tab-stack { width: 100% !important; }
     #TabsToolbar .toolbarbutton-1 { margin: 0 !important; padding: 0 !important; }
 
-    /* Ausblenden */
-    .tabbrowser-tab:not([fadein]),#alltabs-button { display: none !important; }
-
     /* --- Ziehbereich der Tab-Leiste --- */
 
     /* Anpassung */

--- a/Multirowtabs/Firefox-108/05-MultiRowTabLiteforFx.uc.js
+++ b/Multirowtabs/Firefox-108/05-MultiRowTabLiteforFx.uc.js
@@ -48,9 +48,6 @@ function MultiRowTabLiteforFx() {
     .tabbrowser-tab > .tab-stack { width: 100% !important; }
     #TabsToolbar .toolbarbutton-1 { margin: 0 !important; padding: 0 !important; }
 
-    /* Ausblenden - Verstecken */
-    .tabbrowser-tab:not([fadein]),#alltabs-button { display: none !important; }
-
     /* --- Ziehbereich der Tab-Leiste --- */
     
     /* Anpassung */

--- a/Multirowtabs/Firefox-108/06-MultiRowTabLiteforFx.uc.js
+++ b/Multirowtabs/Firefox-108/06-MultiRowTabLiteforFx.uc.js
@@ -50,9 +50,6 @@ function MultiRowTabLiteforFx() {
     .tabbrowser-tab > .tab-stack { width: 100% !important; }
     #TabsToolbar .toolbarbutton-1 { margin: 0 !important; padding: 0 !important; }
 
-    /* Ausblenden - Verstecken */
-    .tabbrowser-tab:not([fadein]),#alltabs-button { display: none !important; }
-
     /* --- Ziehbereich der Tab-Leiste --- */
     /* Anpassung */
     hbox.titlebar-spacer[type="pre-tabs"] { width: 0px !important; } /* Linker Ziehbereich: Standard 40px  */


### PR DESCRIPTION
Hiding all tabs button stopped working properly few versions ago (I think it started with FF 106). Assuming Firefox is configured to restore previous windows and tabs on startup following bug occurrs:

1. Open Firefox
1. Open new tab and visit any page
1. Close this tab
1. Close Firefox
1. Open Firefox
1. **Closed tab is still present**

For some reason hiding all tabs button prevents tabs from terminating properly. This PR provides an easy fix by unhiding this button.